### PR TITLE
Precalculated distance

### DIFF
--- a/clustergrammer/calc_clust.py
+++ b/clustergrammer/calc_clust.py
@@ -49,12 +49,15 @@ def cluster_row_and_col(net, dist_type='cosine', linkage_type='average',
   return dm
 
 def calc_distance_matrix(tmp_mat, inst_rc, dist_type='cosine'):
-  from scipy.spatial.distance import pdist, is_valid_y, squareform
+  from scipy.spatial.distance import pdist, is_valid_y, is_valid_dm, squareform
   import numpy as np
 
   if dist_type in ['precalculated', 'precalc']:
     # convert distance matrix to condensed form if it is not already
-    if not is_valid_y(tmp_mat):
+    # is_valid_y checks if it is already a condensed distance matrix
+    # is_valid_dm checks if it is a valid distance matrix, symmetric with a zero-diagonal
+    if (not is_valid_y(tmp_mat)) and (is_valid_dm(tmp_mat, throw=True)):
+      # convert to condensed distance matrix
       tmp_mat = squareform(tmp_mat)
     return tmp_mat
   if inst_rc == 'row':


### PR DESCRIPTION
Gives the option to use a precalculated distance matrix. The user can do this by specifiying `dist_type='precalculated'` to `Network.cluster()`. The `calc_distance_matrix()` function passes the matrix through, condensing it if it is not already and checking to make sure it is a symmetric distance matrix with a zero-diagonal.

TODO: We might want to allow for nonzero-diagonal and/or non-symmetric matrices in the future.